### PR TITLE
added :keep_git option to prevent deletion of nested .git folder

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,7 @@ end
 
 # Checkout a specific :ref/:tag/:branch
 folder 'vendor/plugins/parallel_tests', 'https://github.com/grosser/parallel_tests.git', :tag => 'v0.6.10'
+# provide :keep_git => true if you don't want the nested .git folder to be deleted
 
 # DRY folders
 folder 'vendor/assets/javascripts' do

--- a/lib/vendorer.rb
+++ b/lib/vendorer.rb
@@ -30,7 +30,7 @@ class Vendorer
         if commit = (options[:ref] || options[:tag] || options[:branch])
           run "cd #{path} && git checkout '#{commit}'"
         end
-        run "rm -rf #{path}/.git"
+        run "rm -rf #{path}/.git" unless options[:keep_git]
         yield path if block_given?
       end
     else

--- a/spec/vendorer_spec.rb
+++ b/spec/vendorer_spec.rb
@@ -189,6 +189,12 @@ describe Vendorer do
       ls('its_recursive/.git').first.should include('cannot access')
     end
 
+    it "keeps .git folder if :keep_git is provided" do
+      write 'Vendorfile', "folder 'its_recursive', '../../.git', :keep_git => true"
+      vendorer
+      ls('its_recursive/.git').first.should_not include('cannot access')
+    end
+
     it "does not update an existing folder" do
       vendorer
       write('its_recursive/Gemfile', 'Foo')


### PR DESCRIPTION
hello grosser,

i added a :keep_git option to the folder so vendorer won't delete the nested .git folder.

it's useful when your vendored projects use git submodules for their dependencies and you want to fetch them after cloning, like:

``` ruby
folder 'Vendor/libPusher', 'git://github.com/lukeredpath/libPusher.git', keep_git: true do |path|
  puts "fetching submodules in #{path}"
  `cd #{path} && git submodule init && git submodule update --recursive`  
end
```

best regards
linki
