### PR TITLE
Add `from` scope to allow file fetching from (private, non-GitHub) Git repositories

### DIFF
--- a/lib/vendorer.rb
+++ b/lib/vendorer.rb
@@ -10,28 +10,31 @@ class Vendorer
     eval(content, nil, 'Vendorfile', 1)
   end
 
-  def file(path, url)
+  def file(path, url=nil)
     path = complete_path(path)
     update_or_not path do
       run "mkdir -p #{File.dirname(path)}"
-      run "curl '#{url}' -L -o #{path}"
-      raise "Downloaded empty file" unless File.exist?(path)
+      if @from_git
+        copy_from_git(path, url)
+      else
+        run "curl '#{url}' -L -o #{path}"
+        raise "Downloaded empty file" unless File.exist?(path)
+      end
       yield path if block_given?
     end
   end
 
   def folder(path, url=nil, options={})
-    if url
+    if @from_git || url
       path = complete_path(path)
       update_or_not path do
         run "rm -rf #{path}"
         run "mkdir -p #{File.dirname(path)}"
-        run "git clone '#{url}' #{path}"
-        if commit = (options[:ref] || options[:tag] || options[:branch])
-          run "cd #{path} && git checkout '#{commit}'"
+        if @from_git
+          copy_from_git(path, url)
+        else
+          git_clone(path, url, options)
         end
-        run("cd #{path} && git submodule update --init --recursive")
-        run "rm -rf #{path}/.git"
         yield path if block_given?
       end
     else
@@ -59,6 +62,15 @@ class Vendorer
     File.open('Vendorfile', 'w') { |f| f.write(examples.strip) }
   end
 
+  def from(url, options={})
+    Dir.mktmpdir do |tmpdir|
+      git_clone tmpdir, url, options
+      @from_git, @from_path = url, tmpdir
+      yield
+      @from_git = @from_path = nil
+    end
+  end
+
   private
 
   def update_or_not(path)
@@ -83,5 +95,21 @@ class Vendorer
 
   def complete_path(path)
     File.join(@sub_path + [path])
+  end
+
+  def git_clone(path, url, options)
+    run "git clone '#{url}' #{path}"
+    if commit = (options[:ref] || options[:tag] || options[:branch])
+      run "cd #{path} && git checkout '#{commit}'"
+    end
+    run("cd #{path} && git submodule update --init --recursive")
+    run "rm -rf #{path}/.git"
+  end
+
+  def copy_from_git(dest_path, src_path)
+    src_path = dest_path if src_path.nil?
+    copy_from = File.join(@from_path, src_path)
+    raise "'#{src_path}' not found in #{@from_git}" unless File.exist?(copy_from)
+    run "cp -Rp #{copy_from} #{dest_path}"
   end
 end

--- a/spec/vendorer_spec.rb
+++ b/spec/vendorer_spec.rb
@@ -441,4 +441,40 @@ describe Vendorer do
       end
     end
   end
+  
+  describe "#from" do
+    def valid_vendorfile
+      write "Vendorfile", "
+      from '../../.git', :tag => 'b1e6460' do
+        file 'Readme.md'
+        file 'Rakefile.renamed', 'Rakefile'
+        folder 'spec'
+        folder 'spec-renamed', 'spec'
+      end
+      "
+    end
+    
+    def bogus_vendorfile
+      write "Vendorfile", "
+      from '../../.git', :tag => 'b1e6460' do
+        file 'bogus'
+      end
+      "
+    end
+    
+    it "copies appropriate files and folders" do
+      valid_vendorfile
+      vendorer
+      ls(".").sort.should == ['Rakefile.renamed', 'Readme.md', 'Vendorfile', 'spec', 'spec-renamed']
+      %w(spec spec-renamed).each do |spec|
+        ls(spec).should == ['spec_helper.rb', 'vendorer_spec.rb']
+      end
+    end
+    
+    it "gives 'not found' error for non-existent file" do
+      bogus_vendorfile
+      output = vendorer '', :raise => true
+      output.should include("'bogus' not found in ../../.git")
+    end
+  end
 end


### PR DESCRIPTION
Often times I want to use vendorer to grab a single file from a remote Git repository. Currently, the way to do this is using GitHub's raw URL, like this:

```
file "jquery-ui.widget.js", "https://raw.github.com/jquery/jquery-ui/master/ui/jquery.ui.widget.js"
```

However, there two major limitations with this approach:
1. If the GitHub repository isn't public, the raw URL won't work. It is possible to include a authentication token in the URL, but hard-coding a private token into a Vendorfile is not a good idea.
2. More importantly, private or not, these raw URLs only work for GitHub. To fetch single file from a non-GitHub Git repository, there is no easy answer.

My proposal is to introduce a `from` scope that allows a Git repository to be declared; `file` and `folder` declarations within this scope would fetch from that Git repository.

So to rewrite the jQuery example above:

```
from "https://github.com/jquery/jquery-ui.git" do
  file "jquery-ui.widget.js", "ui/jquery.ui.widget.js"
end
```

Following vendorer conventions, Git refs are also supported:

```
from "https://github.com/jquery/jquery-ui.git", :branch => "1-8-stable" do
  file "jquery-ui.widget.js", "ui/jquery.ui.widget.js"
end
```

More importantly, private repositories are supported (assuming of course the developer has SSH set up properly). Nested `folder` declarations work too.

```
from "git@github.com:mbrictson/my-private-repo.git" do
  file "foo"    # Copy foo from my-private-repo/foo
  folder "bin"  # Copy entire bin folder from my-private-repo/bin/
end
```
