### PR TITLE
Fix exception in some cases when `from` nested within `folder`

### DIFF
--- a/lib/vendorer.rb
+++ b/lib/vendorer.rb
@@ -12,31 +12,31 @@ class Vendorer
   end
 
   def file(path, url=nil)
-    path = complete_path(path)
-    update_or_not path do
-      run "mkdir -p #{File.dirname(path)}"
+    target_path = complete_path(path)
+    update_or_not target_path do
+      run "mkdir -p #{File.dirname(target_path)}"
       if @copy_from_url
-        copy_from_path(path, url)
+        copy_from_path(target_path, url || path)
       else
-        run "curl '#{url}' -L -o #{path}"
-        raise "Downloaded empty file" unless File.exist?(path)
+        run "curl '#{url}' -L -o #{target_path}"
+        raise "Downloaded empty file" unless File.exist?(target_path)
       end
-      yield path if block_given?
+      yield target_path if block_given?
     end
   end
 
   def folder(path, url=nil, options={})
     if @copy_from_path or url
-      path = complete_path(path)
-      update_or_not path do
-        run "rm -rf #{path}"
-        run "mkdir -p #{File.dirname(path)}"
+      target_path = complete_path(path)
+      update_or_not target_path do
+        run "rm -rf #{target_path}"
+        run "mkdir -p #{File.dirname(target_path)}"
         if @copy_from_path
-          copy_from_path(path, url)
+          copy_from_path(target_path, url || path)
         else
-          download_repository(url, path, options)
+          download_repository(url, target_path, options)
         end
-        yield path if block_given?
+        yield target_path if block_given?
       end
     else
       @sub_path << path

--- a/spec/vendorer_spec.rb
+++ b/spec/vendorer_spec.rb
@@ -534,6 +534,23 @@ describe Vendorer do
       end
     end
 
+    context "with folder nesting" do
+      it "copies" do
+        write "Vendorfile", "
+          folder 'foo' do
+            from '../../.git' do
+              folder 'lib'
+              file 'Gemfile'
+            end
+          end
+        "
+        vendorer
+        ls(".").should == ['foo', 'Vendorfile']
+        ls("./foo").should == ['Gemfile', 'lib']
+        ls("./foo/lib").should == ['vendorer', 'vendorer.rb']
+      end
+    end
+
     it "gives 'not found' error for non-existent file" do
       write "Vendorfile", "
         from '../../.git', :tag => 'b1e6460' do


### PR DESCRIPTION
Consider a one-argument call to `folder` or `file` used within a `from` block, which itself is nested within a `folder`, like so:

```
folder 'vendor/assets/javascripts' do
  from 'https://github.com/harvesthq/chosen.git' do
    folder 'chosen'
  end
end
```

In this case `folder 'chosen'` is a shortcut for `folder 'chosen', 'chosen'`.

However, due a bug, this was incorrectly being interpreted as:

```
folder 'vendor/assets/javascripts/chosen', 'chosen'
```

As a result, an exception would be thrown:

```
'vendor/assets/javascripts/chosen' not found in https://github.com/harvesthq/chosen.git (RuntimeError)
```

This commit fixes this bug by preventing the folder block from affecting the source path. It still affects the target path, as intended.
