### PR TITLE
Making 'vendorer init' command work by including Readme.md back in GEM 

### DIFF
--- a/vendorer.gemspec
+++ b/vendorer.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new name, Vendorer::VERSION do |s|
   s.authors = ["Michael Grosser"]
   s.email = "michael@grosser.it"
   s.homepage = "https://github.com/grosser/#{name}"
-  s.files = `git ls-files lib`.split("\n")
+  s.files = `git ls-files lib`.split("\n") << "Readme.md"
   s.license = 'MIT'
   s.executables = ["vendorer"]
 end


### PR DESCRIPTION
Running `vendorer init` raises exception:

```
/Users/[...]/.rvm/gems/ruby-2.0.0-p247@[...]/gems/vendorer-0.1.15/lib/vendorer.rb:57:in `read': No such file or directory - /Users/[...]/.rvm/gems/ruby-2.0.0-p247@[...]/gems/vendorer-0.1.15/Readme.md (Errno::ENOENT)
    from /Users/[...]/.rvm/gems/ruby-2.0.0-p247@[...]/gems/vendorer-0.1.15/lib/vendorer.rb:57:in `init'
    from /Users/[...]/.rvm/gems/ruby-2.0.0-p247@[...]/gems/vendorer-0.1.15/bin/vendorer:36:in `<top (required)>'
```

`vendorer init` command uses Readme.md to generate sample Vendorfile. After commit 02384a439023b0a7f42994067128110b5281360f, Readme.md is no longer included in .gem package, making `vendorer init` to not work.

This pull request simply makes Readme.md to be again included in .gem.
